### PR TITLE
fix(moviepilot): 修正 v2 容器内 NGINX 与 API 端口冲突导致的无法登录/进程退出

### DIFF
--- a/apps/moviepilot/fnos/docker/docker-compose.yaml
+++ b/apps/moviepilot/fnos/docker/docker-compose.yaml
@@ -18,7 +18,11 @@ services:
       - PUID=${TRIM_UID}
       - PGID=${TRIM_GID}
       - UMASK=022
-      - PORT=3000
+      # v2 架构：NGINX_PORT=Web 入口(须与下方 ports 的容器端口一致)，PORT=后端 API(默认 3001)。
+      # 切勿把 PORT 设为 3000，否则会与 nginx 抢端口或导致代理无法命中 Python，登录等 API 会失败。
+      - NGINX_PORT=3000
+      - PORT=3001
       - GITHUB_PROXY=https://gh-proxy.com/
+      - SUPERUSER=admin
       - SUPERUSER_PASSWORD=${SUPERUSER_PASSWORD:-password}
     restart: unless-stopped


### PR DESCRIPTION
## 背景

MoviePilot v2 官方镜像在容器内采用 **Nginx 对外监听 `NGINX_PORT`（默认 3000）**，**Python API（Uvicorn）监听 `PORT`（默认 3001）**，并由 Nginx 将 API 反代到 `127.0.0.1:${PORT}`。

当前包内 `docker-compose` 将 **`PORT` 设为 `3000`**，会导致 **Uvicorn 与 Nginx 争抢 `3000`**，出现 `address already in use`，应用启动后立即退出；前端表现为 **无法登录**、接口异常等，与是否清空数据目录无关。

## 改动

- 在 `apps/moviepilot/fnos/docker/docker-compose.yaml` 中显式设置：
  - `NGINX_PORT=3000`（与 `ports` 中映射的容器端口 `3000` 一致）
  - `PORT=3001`（后端 API，与官方默认及 Nginx upstream 一致）
- 增加 `SUPERUSER=admin`，与官方文档及向导说明一致。
- 保留 `SUPERUSER_PASSWORD=${SUPERUSER_PASSWORD:-password}` 行为不变。

## 验证

- 本地使用官方镜像对照：`PORT=3000` 时日志可见  
  `ERROR: [Errno 98] ... bind on address ('0.0.0.0', 3000): address already in use`；  
  使用 `NGINX_PORT=3000` + `PORT=3001` 时日志为  
  `Uvicorn running on http://0.0.0.0:3001`，容器可稳定运行。

```yml
services:
  moviepilot-bad:
    image: ${DOCKER_MIRROR-m.daocloud.io/}docker.io/jxxghp/moviepilot-v2:latest
    container_name: moviepilot-verify-bad
    ports:
      - "13000:3000"
    volumes:
      - ./verify-data-bad/config:/config
      - ./verify-data-bad/core:/moviepilot
      - ./verify-data-bad/media:/media
      - ./verify-data-bad/downloads:/downloads
    environment:
      - TZ=Asia/Shanghai
      - PUID=1000
      - PGID=1000
      # Intentionally wrong: clashes with NGINX_PORT default 3000 / breaks upstream proxy.
      - PORT=3000
      - SUPERUSER=admin
      - SUPERUSER_PASSWORD=password

  moviepilot-good:
    image: ${DOCKER_MIRROR-m.daocloud.io/}docker.io/jxxghp/moviepilot-v2:latest
    container_name: moviepilot-verify-good
    ports:
      - "13001:3000"
    volumes:
      - ./verify-data-good/config:/config
      - ./verify-data-good/core:/moviepilot
      - ./verify-data-good/media:/media
      - ./verify-data-good/downloads:/downloads
    environment:
      - TZ=Asia/Shanghai
      - PUID=1000
      - PGID=1000
      - NGINX_PORT=3000
      - PORT=3001
      - SUPERUSER=admin
      - SUPERUSER_PASSWORD=password
```