### PR TITLE
feat(zonefoundry-bridge): enable 1-tap self-update via docker socket

### DIFF
--- a/apps/zonefoundry-bridge/CHANGELOG.md
+++ b/apps/zonefoundry-bridge/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2026-05-12
+
+- 启用 1-tap self-update：挂载 `/var/run/docker.sock` + `group_add: ["999"]`，让 ZoneFoundry iOS app 的"升级"按钮直接拉取并应用新镜像，不用 SSH 或 Container Manager
+- 跟 Unraid CA 模板 (`selfhosters/unRAID-CA-templates#668`) 行为一致
+
 ## 2026-05-10
 
 - 首次发布

--- a/apps/zonefoundry-bridge/README.md
+++ b/apps/zonefoundry-bridge/README.md
@@ -23,6 +23,16 @@
 - 不监听独立端口；fnOS 应用图标仅作占位
 - 镜像同时支持 amd64 / arm64
 
+## 1-tap 自动更新
+
+`docker-compose.yaml` 默认挂载 `/var/run/docker.sock` 并加 `group_add: ["999"]`（飞牛/Debian docker 组 GID）。当 ZoneFoundry iOS App 的 Bridges 页面出现"升级"按钮时，点一下即可：
+
+1. Bridge 通过 docker socket 拉取最新镜像
+2. SIGTERM 自身让 fnOS Apps 用新镜像重启容器
+3. 全程不用 SSH / Container Manager / 手动 recreate
+
+如果你不想让 Bridge 有 docker socket 访问权限，可在安装后编辑 `docker-compose.yaml` 删除 socket 挂载和 `group_add`，改回手动通过 fnOS Apps 升级。
+
 ## 本地构建
 
 ```bash

--- a/apps/zonefoundry-bridge/fnos/docker/docker-compose.yaml
+++ b/apps/zonefoundry-bridge/fnos/docker/docker-compose.yaml
@@ -5,6 +5,15 @@ services:
     network_mode: host
     volumes:
       - ${TRIM_PKGVAR:?}/data:/app/data
+      # 1-tap self-update: lets the bridge pull its own image from
+      # Docker Hub when the user taps "升级" in the iOS app's Bridges
+      # screen. Remove this mount + the group_add entry below if you
+      # prefer to update manually via fnOS Apps.
+      - /var/run/docker.sock:/var/run/docker.sock
+    # 飞牛 fnOS / Debian 默认 docker 组 GID = 999. 让非 root 容器
+    # 用户 (UID 10001) 也能跟 docker socket 讲话.
+    group_add:
+      - "999"
     environment:
       - TZ=Asia/Shanghai
       - ZF_RELAY_URL=wss://relay.zonefoundry.dev/ws


### PR DESCRIPTION
## Summary
- Mount `/var/run/docker.sock` and add `group_add: ["999"]` (fnOS / Debian docker group GID) so the non-root bridge container can pull and apply its own image updates from Docker Hub when the user taps "升级" in the ZoneFoundry iOS app's Bridges screen.
- Updates `CHANGELOG.md` and adds a "1-tap 自动更新" section to the README explaining the new mount + how to opt out.
- No other behaviour changes — host network, the existing data volume, env vars, and `restart: unless-stopped` are all unchanged.

## Why
The bridge ships an in-binary update handler (v0.1.43+) that talks to the docker socket via the standard Unix HTTP API, streams pull progress over WebSocket to the relay, and SIGTERMs itself once the new image is pulled so the container is recreated with the fresh image. Without the socket mount, "Apply Update" from the iOS app fails loud with "docker socket not mounted" — this PR closes that gap for fnOS users so 1-tap update works out of the box. Mirrors selfhosters/unRAID-CA-templates#668 (the CA template counterpart).

## Test plan
- [x] docker-compose YAML validates (`docker compose config` clean)
- [x] Same approach already verified working on Synology DSM (manual mount) and Unraid CA template
- [ ] Fresh install via fnOS Apps on a real or VM飞牛 instance — pair, run, then trigger Apply Update from iOS and confirm new image is pulled and bridge restarts (Sam plans to test on a 飞牛 VM)

If `999` is wrong for some fnOS releases, happy to switch to a wizard-driven approach in `service-setup` that detects the host docker GID. Let me know what you'd prefer.