### PR TITLE
fix(firefox): 修复 VNC 密码不生效，改用 .vncpass_clear 文件方式

### DIFF
--- a/apps/firefox/fnos/cmd/service-setup
+++ b/apps/firefox/fnos/cmd/service-setup
@@ -24,16 +24,11 @@ sanitize_vnc_password() {
 }
 
 service_postinst() {
-    local env_file="${TRIM_APPDEST}/docker/.env"
-
     mkdir -p "${TRIM_PKGVAR}/config" 2>/dev/null || true
     mkdir -p "${TRIM_PKGVAR}/fonts" 2>/dev/null || true
 
-    # ALWAYS write .env, even if user did not supply a password.
-    # docker-compose.yaml declares \`env_file: [.env]\` so the file MUST exist
-    # (otherwise compose fails). We write VNC_PASSWORD=\"\" by default which leaves
-    # the GUI unprotected (jlesage default behavior), and overwrite with the
-    # sanitized wizard value when present.
+    # Write VNC password via .vncpass_clear file in the /config volume.
+    # jlesage containers read this file on startup (preferred over env var).
     local clean=""
     if [ -n "${wizard_password}" ]; then
         clean="$(sanitize_vnc_password "${wizard_password}")"
@@ -41,29 +36,13 @@ service_postinst() {
             install_log "wizard_password contained only invalid characters; VNC auth NOT enabled"
         fi
     fi
-    cat > "$env_file" <<EOF
-# Written by service_postinst at install time.
-# Edit VNC_PASSWORD below and restart Firefox to change the access password.
-VNC_PASSWORD=${clean}
-EOF
-    chmod 600 "$env_file"
     if [ -n "$clean" ]; then
-        install_log "Wrote docker .env: VNC_PASSWORD set (sanitized length=${#clean})"
+        printf '%s' "$clean" > "${TRIM_PKGVAR}/config/.vncpass_clear"
+        chmod 600 "${TRIM_PKGVAR}/config/.vncpass_clear"
+        install_log "VNC password set via .vncpass_clear (length=${#clean})"
     else
-        install_log "Wrote docker .env: VNC_PASSWORD empty (no auth, Firefox open to anyone reaching port)"
-    fi
-}
-
-service_preupgrade() {
-    if [ -f "${TRIM_APPDEST}/docker/.env" ]; then
-        cp "${TRIM_APPDEST}/docker/.env" "${TRIM_PKGVAR}/.env.bak"
-    fi
-}
-
-service_restore() {
-    if [ -f "${TRIM_PKGVAR}/.env.bak" ]; then
-        cp "${TRIM_PKGVAR}/.env.bak" "${TRIM_APPDEST}/docker/.env"
-        rm -f "${TRIM_PKGVAR}/.env.bak"
+        rm -f "${TRIM_PKGVAR}/config/.vncpass_clear"
+        install_log "VNC password not set (no auth)"
     fi
 }
 

--- a/apps/firefox/fnos/docker/docker-compose.yaml
+++ b/apps/firefox/fnos/docker/docker-compose.yaml
@@ -7,14 +7,6 @@ services:
     volumes:
       - ${TRIM_PKGVAR:?}/config:/config
       - ${TRIM_PKGVAR:?}/fonts:/usr/share/fonts
-    # Explicit env_file directive: fnOS framework invokes \`docker compose\` from a
-    # path that does NOT auto-discover \`.env\` from the compose-file directory. This
-    # directive forces docker compose to load /var/apps/firefox/docker/.env so the
-    # wizard-supplied VNC_PASSWORD actually reaches the container (issue #146).
-    # service_postinst ALWAYS writes .env (with VNC_PASSWORD empty by default) to
-    # guarantee this file exists.
-    env_file:
-      - .env
     environment:
       - USER_ID=${TRIM_UID}
       - GROUP_ID=${TRIM_GID}


### PR DESCRIPTION
## 问题
`env_file` 指令在 fnOS 上不生效。fnOS 使用 Docker API 直接管理容器， 不通过 `docker compose` CLI，因此 docker-compose.yaml 中的 `env_file` 指令被忽略，导致 service_postinst 写入 .env 的 VNC_PASSWORD 永远不会 传递到容器。

## 修复
改用 jlesage 镜像原生支持的 `.vncpass_clear` 文件方式：
- 安装向导收集密码
- service_postinst 将密码写入 `${TRIM_PKGVAR}/config/.vncpass_clear`
- 容器启动时 jlesage 自动读取并启用 VNC 密码认证

## 改动
- docker-compose.yaml: 移除无效的 env_file 配置
- cmd/service-setup: 用写 .vncpass_clear 文件替代写 .env 文件
- 移除 service_preupgrade / service_restore 中的 .env 备份逻辑 （.vncpass_clear 在持久化卷上，升级不会丢失，无需备份）

Closes #146