### PR TITLE
fix(moviepilot): 修复密码不生效，改用 compose 变量替换

### DIFF
--- a/apps/moviepilot/fnos/cmd/service-setup
+++ b/apps/moviepilot/fnos/cmd/service-setup
@@ -5,14 +5,8 @@
 # values or with empty values that let the compose-side defaults take over.
 
 service_postinst() {
-    local env_file="${TRIM_APPDEST}/docker/.env"
-
-    # Always write .env (env_file directive in compose.yaml requires it).
-    # SUPERUSER_PASSWORD must be supplied here (was previously via environment:
-    # interpolation which silently lost wizard value because env_file does not
-    # feed Compose-time interpolation). Default 'password' preserves original
-    # behavior when wizard left blank.
-    : > "$env_file"
+    # Apply wizard-specified directories (compose volumes section uses
+    # ${MEDIA_DIR:-...} / ${DOWNLOAD_DIR:-...} which are sed-patched here).
     if [ -n "${wizard_media_dir}" ]; then
         apply_media_dir "${wizard_media_dir}"
         mkdir -p "${wizard_media_dir}" 2>/dev/null || true
@@ -21,13 +15,6 @@ service_postinst() {
         apply_download_dir "${wizard_download_dir}"
         mkdir -p "${wizard_download_dir}" 2>/dev/null || true
     fi
-    if [ -n "${wizard_password}" ]; then
-        echo "SUPERUSER_PASSWORD=${wizard_password}" >> "$env_file"
-    else
-        echo "SUPERUSER_PASSWORD=password" >> "$env_file"
-    fi
-    chmod 600 "$env_file"
-    install_log "Wrote docker .env (wizard values applied where supplied)"
 
     # Create default directories and fix ownership for PUID/PGID
     mkdir -p "${TRIM_PKGVAR}/config" "${TRIM_PKGVAR}/core" "${TRIM_PKGVAR}/media" "${TRIM_PKGVAR}/downloads" 2>/dev/null || true
@@ -35,15 +22,23 @@ service_postinst() {
 }
 
 service_preupgrade() {
-    if [ -f "${TRIM_APPDEST}/docker/.env" ]; then
-        cp "${TRIM_APPDEST}/docker/.env" "${TRIM_PKGVAR}/.env.bak"
+    # Backup persisted values for restore after upgrade
+    if [ -f "$MEDIA_DIR_SAVE" ]; then
+        cp "$MEDIA_DIR_SAVE" "${TRIM_PKGVAR}/.media_dir.bak"
+    fi
+    if [ -f "$DOWNLOAD_DIR_SAVE" ]; then
+        cp "$DOWNLOAD_DIR_SAVE" "${TRIM_PKGVAR}/.download_dir.bak"
     fi
 }
 
 service_restore() {
-    if [ -f "${TRIM_PKGVAR}/.env.bak" ]; then
-        cp "${TRIM_PKGVAR}/.env.bak" "${TRIM_APPDEST}/docker/.env"
-        rm -f "${TRIM_PKGVAR}/.env.bak"
+    if [ -f "${TRIM_PKGVAR}/.media_dir.bak" ]; then
+        apply_media_dir "$(cat "${TRIM_PKGVAR}/.media_dir.bak")"
+        rm -f "${TRIM_PKGVAR}/.media_dir.bak"
+    fi
+    if [ -f "${TRIM_PKGVAR}/.download_dir.bak" ]; then
+        apply_download_dir "$(cat "${TRIM_PKGVAR}/.download_dir.bak")"
+        rm -f "${TRIM_PKGVAR}/.download_dir.bak"
     fi
 }
 
@@ -82,34 +77,14 @@ apply_port() {
 }
 
 service_postupgrade() {
-    local env_file="${TRIM_APPDEST}/docker/.env"
-
     if [ -f "$PORT_SAVE" ]; then
         apply_port "$(cat "$PORT_SAVE")"
     fi
-
-    # MEDIA_DIR: prefer persisted save file; fall back to migrating from .env
-    # for users upgrading from earlier broken revisions that wrote to .env only.
     if [ -f "$MEDIA_DIR_SAVE" ]; then
         apply_media_dir "$(cat "$MEDIA_DIR_SAVE")"
-    elif [ -f "$env_file" ]; then
-        local mv
-        mv="$(grep -E '^MEDIA_DIR=' "$env_file" | head -1 | cut -d= -f2-)"
-        if [ -n "$mv" ]; then
-            install_log "Migrating MEDIA_DIR from .env (legacy): $mv"
-            apply_media_dir "$mv"
-        fi
     fi
-
     if [ -f "$DOWNLOAD_DIR_SAVE" ]; then
         apply_download_dir "$(cat "$DOWNLOAD_DIR_SAVE")"
-    elif [ -f "$env_file" ]; then
-        local dv
-        dv="$(grep -E '^DOWNLOAD_DIR=' "$env_file" | head -1 | cut -d= -f2-)"
-        if [ -n "$dv" ]; then
-            install_log "Migrating DOWNLOAD_DIR from .env (legacy): $dv"
-            apply_download_dir "$dv"
-        fi
     fi
 }
 

--- a/apps/moviepilot/fnos/docker/docker-compose.yaml
+++ b/apps/moviepilot/fnos/docker/docker-compose.yaml
@@ -7,32 +7,16 @@ services:
     volumes:
       - ${TRIM_PKGVAR:?}/config:/config
       - ${TRIM_PKGVAR:?}/core:/moviepilot
-      # MEDIA_DIR / DOWNLOAD_DIR come from .env (written by install wizard).
-      # These MUST match the directories used by your download client (e.g. qBittorrent),
-      # otherwise MoviePilot cannot find downloaded files for organizing.
-      # Defaults fall back to app-private dirs which other apps cannot access.
       - ${MEDIA_DIR:-${TRIM_PKGVAR:?}/media}:/media
       - ${DOWNLOAD_DIR:-${TRIM_PKGVAR:?}/downloads}:/downloads
-    # Explicit env_file directive so the wizard-written .env actually reaches
-    # docker compose. fnOS framework invokes \`docker compose\` from a cwd that
-    # does NOT auto-discover compose-file-directory \`.env\`. Without this
-    # directive, SUPERUSER_PASSWORD / MEDIA_DIR / DOWNLOAD_DIR set by the wizard
-    # were silently ignored (same plumbing bug fixed in firefox/chromium #146).
-    # service_postinst ALWAYS writes .env to ensure this file exists.
-    env_file:
-      - .env
     environment:
       - TZ=Asia/Shanghai
       - PUID=${TRIM_UID}
       - PGID=${TRIM_GID}
       - UMASK=022
-      # v2 架构：NGINX_PORT=Web 入口(须与下方 ports 的容器端口一致)，PORT=后端 API(默认 3001)。
-      # 切勿把 PORT 设为 3000，否则会与 nginx 抢端口或导致代理无法命中 Python，登录等 API 会失败。
       - NGINX_PORT=3000
       - PORT=3001
       - GITHUB_PROXY=https://gh-proxy.com/
       - SUPERUSER=admin
-      # SUPERUSER_PASSWORD is supplied via env_file (seed = 'password',
-      # service_postinst overwrites with wizard value). Do NOT add it to environment:
-      # — environment: overrides env_file and would shadow the wizard value.
+      - SUPERUSER_PASSWORD=${wizard_password:-password}
     restart: unless-stopped

--- a/scripts/apps/moviepilot/build.sh
+++ b/scripts/apps/moviepilot/build.sh
@@ -12,22 +12,6 @@ mkdir -p "${WORK_DIR}/docker"
 cp "${SCRIPT_DIR}/../../../apps/moviepilot/fnos/docker/docker-compose.yaml" "${WORK_DIR}/docker/"
 sed -i "s/\${VERSION}/${VERSION}/g" "${WORK_DIR}/docker/docker-compose.yaml"
 
-# Seed .env so docker compose validates BEFORE service_postinst runs.
-# docker-compose.yaml declares env_file: [.env] which requires the file to
-# exist at compose validation time. service_postinst overwrites with wizard values.
-# Default SUPERUSER_PASSWORD=password matches MoviePilot's documented initial creds.
-cat > "${WORK_DIR}/docker/.env" <<'EOF'
-# Seed file shipped in fpk. Overwritten by service_postinst at install time.
-SUPERUSER_PASSWORD=password
-EOF
-
-# Seed .env so docker compose validates BEFORE service_postinst runs.
-# docker-compose.yaml declares env_file: [.env] which requires the file to
-# exist at compose validation time. service_postinst overwrites with wizard values.
-cat > "${WORK_DIR}/docker/.env" <<'EOF'
-# Seed file shipped in fpk. Will be overwritten by service_postinst.
-EOF
-
 cp -a "${SCRIPT_DIR}/../../../apps/moviepilot/fnos/ui" "${WORK_DIR}/ui"
 
 cd "${WORK_DIR}"


### PR DESCRIPTION
## 问题
`env_file` 指令在 fnOS 上不生效。fnOS 自己解析 docker-compose.yaml 并做变量替换，但不会处理 env_file 指令，导致 SUPERUSER_PASSWORD
永远传不到容器。

## 修复
fnOS 官方文档说明 "docker-compose.yaml 允许使用环境变量，在执行前
将进行替换"。直接利用此机制，将 SUPERUSER_PASSWORD 改为 compose
变量替换 `${wizard_password:-password}`，不再依赖 env_file。

## 改动
- docker-compose.yaml: 删除 env_file，SUPERUSER_PASSWORD 使用 ${wizard_password:-password}
- cmd/service-setup: 删除 .env 写入/备份/恢复/迁移逻辑
- scripts/apps/moviepilot/build.sh: 删除重复的 .env 种子写入